### PR TITLE
keep showing chip counts for disconnected users

### DIFF
--- a/lib/chippy/sprint.ex
+++ b/lib/chippy/sprint.ex
@@ -37,7 +37,7 @@ defmodule Chippy.Sprint do
   def sorted_allocations(sprint) do
     sprint.project_allocations
     |> Map.to_list()
-    |> Enum.sort_by(fn {k, v} -> k end)
+    |> Enum.sort_by(fn {k, _v} -> k end)
   end
 
   defp add_chips_to_project(project, person_name, chip_count) do

--- a/lib/chippy/sprint.ex
+++ b/lib/chippy/sprint.ex
@@ -157,30 +157,6 @@ defmodule Chippy.Sprint do
   end
 
   @doc """
-  Returns the users and their total chips placed in the sprint.
-
-    iex> Sprint.new(["Foo", "Bar"]) \
-      |> Sprint.add_chips("Foo", "nmashton", 2) \
-      |> Sprint.add_chips("Foo", "vkurup", 3) \
-      |> Sprint.add_chips("Bar", "vkurup", 1) \
-      |> Sprint.user_chip_counts
-    [{"nmashton", 2}, {"vkurup", 4}]
-  """
-  def user_chip_counts(sprint) do
-    for {user, projects} <- Sprint.display_by_users(sprint) do
-      {user,
-       projects
-       |> Map.values()
-       |> Enum.sum()}
-    end
-    |> Enum.sort()
-  end
-
-  def user_chip_count(sprint, user_name) do
-    Sprint.display_by_users(sprint) |> Map.get(user_name, %{}) |> Map.values() |> Enum.sum()
-  end
-
-  @doc """
   Returns the projects for a sprint, sorted alphabetically.
 
     iex> Sprint.new(["Foo", "Bar"]) |> Sprint.display_projects

--- a/lib/chippy_web/controllers/page_controller.ex
+++ b/lib/chippy_web/controllers/page_controller.ex
@@ -23,14 +23,14 @@ defmodule ChippyWeb.PageController do
 
   def profile_save(conn, %{"profile" => %{"user_id" => user_id}}) do
     conn
-    |> put_session(:user_id, user_id)
+    |> put_session(:user_id, String.trim(user_id))
     |> put_flash(:info, "Profile saved successfully.")
     |> redirect(to: Routes.page_path(conn, :index))
   end
 
   def sprint(conn, %{"sid" => sprint_id}) do
-    case get_session(conn, :user_id) do
-      user_id when user_id != nil ->
+    case get_session(conn, :user_id) || "" do
+      user_id when user_id != "" ->
         LiveController.live_render(
           conn,
           ChippyWeb.SprintLive.Show,

--- a/lib/chippy_web/controllers/page_controller.ex
+++ b/lib/chippy_web/controllers/page_controller.ex
@@ -2,12 +2,12 @@ defmodule ChippyWeb.PageController do
   use ChippyWeb, :controller
   alias Phoenix.LiveView.Controller, as: LiveController
 
-  alias Chippy.{SprintServer, SprintSupervisor}
+  alias Chippy.SprintSupervisor
   alias ChippyWeb.Router.Helpers, as: Routes
 
   def index(conn, _params) do
     sprints =
-      Supervisor.which_children(Chippy.SprintSupervisor)
+      Supervisor.which_children(SprintSupervisor)
       |> Enum.map(fn {_, pid, _, _} -> pid end)
       |> Enum.map(fn pid -> Registry.keys(:sprint_registry, pid) end)
 

--- a/lib/chippy_web/live/sprint_live/show.ex
+++ b/lib/chippy_web/live/sprint_live/show.ex
@@ -18,7 +18,7 @@ defmodule ChippyWeb.SprintLive.Show do
     end)
   end
 
-  defp online_users(sprint_id) do
+  defp sprint_users(sprint_id) do
     Presence.list("users:" <> sprint_id)
     |> Map.new(fn {name, %{metas: metas}} -> {name, %{device_count: length(metas)}} end)
     |> Map.merge(user_chip_counts(sprint_id), fn _k, a, b -> Map.merge(a, b) end)
@@ -41,7 +41,7 @@ defmodule ChippyWeb.SprintLive.Show do
            name_taken: false,
            errors: "",
            project_name: "",
-           online_users: online_users(sprint_id)
+           sprint_users: sprint_users(sprint_id)
          })}
 
       nil ->
@@ -93,20 +93,20 @@ defmodule ChippyWeb.SprintLive.Show do
 
   def update_sprint(sprint_id, new_sprint, socket) do
     PubSub.broadcast(Chippy.PubSub, "sprint:" <> sprint_id, {:sprints, :update, new_sprint})
-    {:noreply, assign(socket, %{sprint: new_sprint, online_users: online_users(sprint_id)})}
+    {:noreply, assign(socket, %{sprint: new_sprint, sprint_users: sprint_users(sprint_id)})}
   end
 
   def handle_info(
         {:sprints, :update, new_sprint},
         %{assigns: %{sprint_id: sprint_id}} = socket
       ) do
-    {:noreply, assign(socket, %{sprint: new_sprint, online_users: online_users(sprint_id)})}
+    {:noreply, assign(socket, %{sprint: new_sprint, sprint_users: sprint_users(sprint_id)})}
   end
 
   def handle_info(
         %Broadcast{event: "presence_diff"},
         %{assigns: %{sprint_id: sprint_id}} = socket
       ) do
-    {:noreply, assign(socket, online_users: online_users(sprint_id))}
+    {:noreply, assign(socket, sprint_users: sprint_users(sprint_id))}
   end
 end

--- a/lib/chippy_web/live/sprint_live/show.ex
+++ b/lib/chippy_web/live/sprint_live/show.ex
@@ -13,6 +13,7 @@ defmodule ChippyWeb.SprintLive.Show do
 
   defp user_chip_counts(sprint_id) do
     SprintServer.display_by_users(sprint_id)
+    # Create a map of %{"username" => %{chip_count: N}} for all users in the Sprint
     |> Map.new(fn {name, projects} ->
       {name, %{chip_count: projects |> Map.values() |> Enum.sum()}}
     end)
@@ -20,7 +21,12 @@ defmodule ChippyWeb.SprintLive.Show do
 
   defp sprint_users(sprint_id) do
     Presence.list("users:" <> sprint_id)
+    # Create a map of %{"username" => %{device_count: N}} for all online users
     |> Map.new(fn {name, %{metas: metas}} -> {name, %{device_count: length(metas)}} end)
+    # Merge the map of online users with the users and their chip counts from the
+    # SprintServer, so we end up with %{"username" => %{device_count: N, chip_count: N}}.
+    # We need the nested Map.merge since we're merging both the top-level map and its
+    # values per-key (which are also maps).
     |> Map.merge(user_chip_counts(sprint_id), fn _k, a, b -> Map.merge(a, b) end)
   end
 

--- a/lib/chippy_web/live/sprint_live/show.ex
+++ b/lib/chippy_web/live/sprint_live/show.ex
@@ -96,8 +96,11 @@ defmodule ChippyWeb.SprintLive.Show do
     {:noreply, assign(socket, %{sprint: new_sprint, online_users: online_users(sprint_id)})}
   end
 
-  def handle_info({:sprints, :update, new_sprint}, socket) do
-    {:noreply, assign(socket, sprint: new_sprint)}
+  def handle_info(
+        {:sprints, :update, new_sprint},
+        %{assigns: %{sprint_id: sprint_id}} = socket
+      ) do
+    {:noreply, assign(socket, %{sprint: new_sprint, online_users: online_users(sprint_id)})}
   end
 
   def handle_info(

--- a/lib/chippy_web/templates/layout/app.html.eex
+++ b/lib/chippy_web/templates/layout/app.html.eex
@@ -12,7 +12,14 @@
       <section class="container">
         <nav role="navigation">
           <ul>
-            <li><a href="/profile" id="user_id"><%= Plug.Conn.get_session(@conn, :user_id) || "Edit profile" %></a></li>
+            <li>
+              <a href="/profile" id="user_id">
+                <%= case Plug.Conn.get_session(@conn, :user_id) || "" do
+                  "" -> "Edit profile"
+                  user_id -> user_id
+                end %>
+              </a>
+            </li>
           </ul>
         </nav>
         <a href="/">

--- a/lib/chippy_web/templates/page/profile.html.eex
+++ b/lib/chippy_web/templates/page/profile.html.eex
@@ -1,7 +1,6 @@
-
 <section class="row">
   <%= form_for @conn, Routes.page_path(@conn, :profile), [as: :profile], fn f -> %>
-    Name: <%= text_input f, :user_id, value: Plug.Conn.get_session(@conn, :user_id) %>
+    Name: <%= text_input f, :user_id, value: Plug.Conn.get_session(@conn, :user_id), required: "required", autofocus: "autofocus" %>
     <%= submit "Save" %>
   <% end %>
 </section>

--- a/lib/chippy_web/templates/page/sprint_live.html.leex
+++ b/lib/chippy_web/templates/page/sprint_live.html.leex
@@ -71,7 +71,7 @@
             <%= case Map.get(attrs, :device_count, 0) do
               0 -> "(disconnected)"
               1 -> ""
-              _ -> " (" <> Integer.to_string(attrs[:device_count]) <> " devices)"
+              _ -> "(" <> Integer.to_string(attrs[:device_count]) <> " devices)"
               end %>
             <span class="chip user-count" style="background-color: <%= Colorify.hex name %>;">
               <%= Map.get(attrs, :chip_count, 0) %>

--- a/lib/chippy_web/templates/page/sprint_live.html.leex
+++ b/lib/chippy_web/templates/page/sprint_live.html.leex
@@ -65,10 +65,17 @@
   <div class="row">
     <div class="column">
       <ul>
-        <%= for {name, %{metas: metas}} <- assigns[:online_users] do %>
+        <%= for {name, attrs} <- assigns[:online_users] do %>
           <li class="user-info-item">
-            <%= name %><%= if length(metas) > 1, do: " (" <> (metas |> length |> Integer.to_string ) <> " devices)" %>
-            <span class="chip user-count" style="background-color: <%= Colorify.hex name %>;"><%= Sprint.user_chip_count(@sprint, name) %></span>
+            <%= name %>
+            <%= case Map.get(attrs, :device_count, 0) do
+              0 -> "(disconnected)"
+              1 -> ""
+              _ -> " (" <> Integer.to_string(attrs[:device_count]) <> " devices)"
+              end %>
+            <span class="chip user-count" style="background-color: <%= Colorify.hex name %>;">
+              <%= Map.get(attrs, :chip_count, 0) %>
+            </span>
           </li>
         <% end %>
       </ul>

--- a/lib/chippy_web/templates/page/sprint_live.html.leex
+++ b/lib/chippy_web/templates/page/sprint_live.html.leex
@@ -65,7 +65,7 @@
   <div class="row">
     <div class="column">
       <ul>
-        <%= for {name, attrs} <- assigns[:online_users] do %>
+        <%= for {name, attrs} <- assigns[:sprint_users] do %>
           <li class="user-info-item">
             <%= name %>
             <%= case Map.get(attrs, :device_count, 0) do

--- a/lib/chippy_web/templates/page/sprint_live.html.leex
+++ b/lib/chippy_web/templates/page/sprint_live.html.leex
@@ -71,7 +71,7 @@
             <%= case Map.get(attrs, :device_count, 0) do
               0 -> "(disconnected)"
               1 -> ""
-              _ -> "(" <> Integer.to_string(attrs[:device_count]) <> " devices)"
+              x when x > 1 -> "(" <> Integer.to_string(x) <> " devices)"
               end %>
             <span class="chip user-count" style="background-color: <%= Colorify.hex name %>;">
               <%= Map.get(attrs, :chip_count, 0) %>


### PR DESCRIPTION
When a user disconnected, we lost their chip count at the bottom of the page. This should keep any user with chips on the board listed, and notes that they've disconnected. I decided to move `user_chip_counts` to the view since it seemed fairly specific to this use case.

~**There's still a bug in this I haven't figured out:** The chip counts don't update properly when _someone else_ adds/removes chips. Everything else seems to work okay.~