### PR TITLE
Show chip value in hours

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -5,7 +5,7 @@
 .total-count {
   display: flex !important;
   align-items: center;
-  font-size: 200%;
+  font-size: 150%;
   font-weight: bold;
   padding-left: 1em !important;
 }
@@ -15,8 +15,11 @@
   width: 25px;
   background-color: #bbb;
   border-radius: 50%;
-  display: inline-block;
+  display: inline-flex;
   margin: 3px;
+  font-weight: bold;
+  justify-content: center;
+  align-items: center;
 }
 
 .row-chips {
@@ -88,12 +91,8 @@ section.users > ul > li {
 }
 
 .user-count {
-  display: inline-flex;
-  font-weight: bold;
   height: 32px;
   width: 32px;
-  justify-content: center;
-  align-items: center;
   color: white;
   margin-left: 2em;
 }

--- a/config/config.exs
+++ b/config/config.exs
@@ -20,6 +20,10 @@ config :chippy, ChippyWeb.Endpoint,
     signing_salt: "f+vbVpQNIOm++4C/33LWT0Qq+aWj2Etu"
   ]
 
+# Application settings
+config :chippy,
+  hours_per_chip: 4
+
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",

--- a/lib/chippy_web/live/sprint_live/show.ex
+++ b/lib/chippy_web/live/sprint_live/show.ex
@@ -8,6 +8,7 @@ defmodule ChippyWeb.SprintLive.Show do
   alias ChippyWeb.Router.Helpers, as: Routes
 
   def render(assigns) do
+    assigns = Map.put(assigns, :hours_per_chip, Application.get_env(:chippy, :hours_per_chip))
     ChippyWeb.PageView.render("sprint_live.html", assigns)
   end
 

--- a/lib/chippy_web/templates/page/sprint_live.html.leex
+++ b/lib/chippy_web/templates/page/sprint_live.html.leex
@@ -18,13 +18,13 @@
         <%= for {name, chips} <- allocation do %>
           <div class="row row-chips">
             <%= for _i <- 1..chips do %>
-              <span class="chip" style="background-color: <%= Colorify.hex name %>" title="<%= name %>"></span>
+              <span class="chip" style="background-color: <%= Colorify.hex name %>" title="<%= name %>"><%= @hours_per_chip %></span>
             <% end %>
           </div>
         <% end %>
       </div>
       <div class="column column-20 total-count">
-        <%= allocation |> Map.values |> Enum.sum %>
+        <%= allocation |> Map.values |> Enum.map(&(&1 * @hours_per_chip)) |> Enum.sum %> hours
       </div>
     </div>
   <% end %>

--- a/lib/chippy_web/templates/page/sprint_live.html.leex
+++ b/lib/chippy_web/templates/page/sprint_live.html.leex
@@ -74,7 +74,7 @@
               x when x > 1 -> "(" <> Integer.to_string(x) <> " devices)"
               end %>
             <span class="chip user-count" style="background-color: <%= Colorify.hex name %>;">
-              <%= Map.get(attrs, :chip_count, 0) %>
+              <%= Map.get(attrs, :chip_count, 0) * @hours_per_chip %>
             </span>
           </li>
         <% end %>


### PR DESCRIPTION
Fixes #33

This puts a 4 inside each chip (configurable in settings) and shows project total in hours rather
than chips.