### PR TITLE
Associate an optional hour limit on all projects

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2,14 +2,6 @@
 
 @import "./phoenix.css";
 
-.total-count {
-  display: flex !important;
-  align-items: center;
-  font-size: 150%;
-  font-weight: bold;
-  padding-left: 1em !important;
-}
-
 .chip {
   height: 25px;
   width: 25px;
@@ -52,6 +44,10 @@ section.chips>form>.row>.column {
   margin: 0 0.5rem;
   width: 2.8rem;
   text-align: center;
+}
+.button-warning {
+  background-color: crimson;
+  border-color: crimson;
 }
 
 footer {

--- a/lib/chippy/sprint.ex
+++ b/lib/chippy/sprint.ex
@@ -29,9 +29,23 @@ defmodule Chippy.Sprint do
     }
   """
   def add_project(sprint, project_name, hour_limit) do
+    hour_limit =
+      case Integer.parse(hour_limit) do
+        # returns a 2-tuple if successful parse with value in first tuple
+        {hour_limit, _} -> hour_limit
+        :error -> 0
+      end
+
     %Sprint{
       project_allocations: Map.put(sprint.project_allocations, project_name, %{}),
       project_limits: Map.put(sprint.project_limits, project_name, hour_limit)
+    }
+  end
+
+  def delete_project(sprint, project_name) do
+    %Sprint{
+      project_allocations: Map.delete(sprint.project_allocations, project_name),
+      project_limits: Map.delete(sprint.project_limits, project_name)
     }
   end
 
@@ -171,9 +185,5 @@ defmodule Chippy.Sprint do
     sprint.project_allocations
     |> Enum.map(fn {project_name, _} -> project_name end)
     |> Enum.sort()
-  end
-
-  def hour_limit(sprint, project_name) do
-    sprint.project_limits[project_name]
   end
 end

--- a/lib/chippy/sprint.ex
+++ b/lib/chippy/sprint.ex
@@ -22,10 +22,12 @@ defmodule Chippy.Sprint do
   @doc """
   Adds a new empty project to a sprint.
 
+  Takes a project_name and an optional hour_limit which is converted to an integer.
+
     iex> Sprint.new([]) |> Sprint.add_project("Foo", "22")
     %Sprint{
       project_allocations: %{"Foo" => %{}},
-      project_limits: %{"Foo" => "22"}
+      project_limits: %{"Foo" => 22}
     }
   """
   def add_project(sprint, project_name, hour_limit) do

--- a/lib/chippy/sprint.ex
+++ b/lib/chippy/sprint.ex
@@ -1,6 +1,7 @@
 defmodule Chippy.Sprint do
   @derive Jason.Encoder
-  defstruct project_allocations: %{}
+  defstruct project_allocations: %{},
+            project_limits: %{}
 
   alias Chippy.Sprint
 
@@ -21,12 +22,16 @@ defmodule Chippy.Sprint do
   @doc """
   Adds a new empty project to a sprint.
 
-    iex> Sprint.new([]) |> Sprint.add_project("Foo")
-    %Sprint{project_allocations: %{"Foo" => %{}}}
-  """
-  def add_project(sprint, project_name) do
+    iex> Sprint.new([]) |> Sprint.add_project("Foo", "22")
     %Sprint{
-      project_allocations: Map.put(sprint.project_allocations, project_name, %{})
+      project_allocations: %{"Foo" => %{}},
+      project_limits: %{"Foo" => "22"}
+    }
+  """
+  def add_project(sprint, project_name, hour_limit) do
+    %Sprint{
+      project_allocations: Map.put(sprint.project_allocations, project_name, %{}),
+      project_limits: Map.put(sprint.project_limits, project_name, hour_limit)
     }
   end
 
@@ -166,5 +171,9 @@ defmodule Chippy.Sprint do
     sprint.project_allocations
     |> Enum.map(fn {project_name, _} -> project_name end)
     |> Enum.sort()
+  end
+
+  def hour_limit(sprint, project_name) do
+    sprint.project_limits[project_name]
   end
 end

--- a/lib/chippy/sprint_server.ex
+++ b/lib/chippy/sprint_server.ex
@@ -20,6 +20,12 @@ defmodule Chippy.SprintServer do
     |> GenServer.call({:add_project, project_name, hour_limit})
   end
 
+  def delete_project(sprint_name, project_name) do
+    sprint_name
+    |> via_tuple
+    |> GenServer.call({:delete_project, project_name})
+  end
+
   def has_project?(sprint_name, project_name) do
     sprint_name
     |> via_tuple
@@ -67,6 +73,11 @@ defmodule Chippy.SprintServer do
 
   def handle_call({:has_project, project_name}, _from, sprint) do
     {:reply, Sprint.has_project?(sprint, project_name), sprint, @timeout}
+  end
+
+  def handle_call({:delete_project, project_name}, _from, sprint) do
+    new_sprint = Sprint.delete_project(sprint, project_name)
+    {:reply, new_sprint, new_sprint, @timeout}
   end
 
   def handle_call({:add_chip, project_name, person_name}, _from, sprint) do

--- a/lib/chippy/sprint_server.ex
+++ b/lib/chippy/sprint_server.ex
@@ -14,10 +14,10 @@ defmodule Chippy.SprintServer do
   end
 
   # Methods
-  def add_project(sprint_name, project_name) do
+  def add_project(sprint_name, project_name, hour_limit) do
     sprint_name
     |> via_tuple
-    |> GenServer.call({:add_project, project_name})
+    |> GenServer.call({:add_project, project_name, hour_limit})
   end
 
   def has_project?(sprint_name, project_name) do
@@ -60,8 +60,8 @@ defmodule Chippy.SprintServer do
     {:ok, sprint, @timeout}
   end
 
-  def handle_call({:add_project, project_name}, _from, sprint) do
-    new_sprint = Sprint.add_project(sprint, project_name)
+  def handle_call({:add_project, project_name, hour_limit}, _from, sprint) do
+    new_sprint = Sprint.add_project(sprint, project_name, hour_limit)
     {:reply, new_sprint, new_sprint, @timeout}
   end
 

--- a/lib/chippy_web/live/sprint_live/show.ex
+++ b/lib/chippy_web/live/sprint_live/show.ex
@@ -81,6 +81,15 @@ defmodule ChippyWeb.SprintLive.Show do
   end
 
   def handle_event(
+        "delete_project",
+        project_name,
+        %{assigns: %{sprint_id: sprint_id}} = socket
+      ) do
+    new_sprint = SprintServer.delete_project(sprint_id, project_name)
+    update_sprint(sprint_id, new_sprint, socket)
+  end
+
+  def handle_event(
         "add_chip",
         project_name,
         %{assigns: %{sprint_id: sprint_id, your_name: person_name}} = socket

--- a/lib/chippy_web/live/sprint_live/show.ex
+++ b/lib/chippy_web/live/sprint_live/show.ex
@@ -73,10 +73,10 @@ defmodule ChippyWeb.SprintLive.Show do
 
   def handle_event(
         "create_project",
-        %{"project_name" => project_name},
+        %{"project_name" => project_name, "hour_limit" => hour_limit},
         %{assigns: %{sprint_id: sprint_id}} = socket
       ) do
-    new_sprint = SprintServer.add_project(sprint_id, project_name)
+    new_sprint = SprintServer.add_project(sprint_id, project_name, hour_limit)
     update_sprint(sprint_id, new_sprint, socket)
   end
 

--- a/lib/chippy_web/templates/page/sprint_live.html.leex
+++ b/lib/chippy_web/templates/page/sprint_live.html.leex
@@ -1,6 +1,15 @@
 <% alias Chippy.Sprint %>
 
 <section class="chips container">
+  <%= if !Enum.empty?(Sprint.sorted_allocations(@sprint)) do %>
+    <div class="row project">
+      <div class="column column-80"></div>
+      <div class="column column-20">
+        <div class="row"><b>Hours Allocated</b></div>
+      </div>
+    </div>
+  <% end %>
+
   <%= for {project_name, allocation} <- Sprint.sorted_allocations(@sprint) do %>
     <div class="row project">
       <div class="column column-20">
@@ -24,14 +33,14 @@
         <% end %>
       </div>
       <div class="column column-20 total-count">
-        <%= allocation |> Map.values |> Enum.map(&(&1 * @hours_per_chip)) |> Enum.sum %> hours
+        <%= allocation |> Map.values |> Enum.map(&(&1 * @hours_per_chip)) |> Enum.sum %> / <%= Sprint.hour_limit(@sprint, project_name) %>
       </div>
     </div>
   <% end %>
 
   <form phx-change="lookup_project" phx-submit="create_project">
     <div class="row">
-      <div class="column column-20">
+      <div class="column column-40">
         <div class="row">
           <input
             type="text"
@@ -39,9 +48,14 @@
             placeholder="Project name"
             autofocus
           />
+          <input
+            type="number"
+            name="hour_limit"
+            placeholder="PM Allocation"
+          />
         </div>
       </div>
-      <div class="column column-20">
+      <div class="column column-40">
         <div class="row">
           <button
             <%= if @project_name == "" || @name_taken, do: "disabled", else: "" %>

--- a/lib/chippy_web/templates/page/sprint_live.html.leex
+++ b/lib/chippy_web/templates/page/sprint_live.html.leex
@@ -3,8 +3,7 @@
 <section class="chips container">
   <%= if !Enum.empty?(Sprint.sorted_allocations(@sprint)) do %>
     <div class="row project">
-      <div class="column column-80"></div>
-      <div class="column column-20">
+      <div class="column column-10 column-offset-20">
         <div class="row"><b>Hours Allocated</b></div>
       </div>
     </div>
@@ -23,6 +22,10 @@
           </button>
         </div>
       </div>
+      <div class="column column-10">
+        <%= allocation |> Map.values |> Enum.map(&(&1 * @hours_per_chip)) |> Enum.sum %> /
+        <%= hour_limit(@sprint, project_name) %>
+      </div>
       <div class="column column-60">
         <%= for {name, chips} <- allocation do %>
           <div class="row row-chips">
@@ -32,8 +35,10 @@
           </div>
         <% end %>
       </div>
-      <div class="column column-20 total-count">
-        <%= allocation |> Map.values |> Enum.map(&(&1 * @hours_per_chip)) |> Enum.sum %> / <%= Sprint.hour_limit(@sprint, project_name) %>
+      <div class="column column-10">
+        <button phx-click="delete_project" phx-value="<%= project_name %>" class="button button-warning">
+          Delete Project
+        </button>
       </div>
     </div>
   <% end %>

--- a/lib/chippy_web/views/page_view.ex
+++ b/lib/chippy_web/views/page_view.ex
@@ -1,3 +1,7 @@
 defmodule ChippyWeb.PageView do
   use ChippyWeb, :view
+
+  def hour_limit(sprint, project_name) do
+    sprint.project_limits[project_name]
+  end
 end


### PR DESCRIPTION
Fixes #35

PM can add an hour limit during project creation and that shows up in the project list.

Currently no way to edit that limit, and nothing happens when dev hours exceed that limit.