### PR TITLE
Remove hardcoded URL path

### DIFF
--- a/lib/chippy_web/router.ex
+++ b/lib/chippy_web/router.ex
@@ -21,7 +21,7 @@ defmodule ChippyWeb.Router do
     get "/", PageController, :index
     get "/profile", PageController, :profile
     post "/profile", PageController, :profile_save
-    live "/sprint/new", SprintLive.New, as: :new_sprint
+    live "/sprint/new", SprintLive.New
     get "/sprint/:sid", PageController, :sprint
   end
 

--- a/lib/chippy_web/templates/page/index.html.eex
+++ b/lib/chippy_web/templates/page/index.html.eex
@@ -7,7 +7,7 @@
 <section class="row">
   <ul>
     <li>
-      <%= link "Start a new sprint", to: "/sprint/new" %>
+      <%= link "Start a new sprint", to: Routes.live_path(@conn, ChippyWeb.SprintLive.New) %>
     </li>
     <li>Join an existing sprint</li>
     <ul>


### PR DESCRIPTION
I figured out why I couldn't fix the hardcoded `/sprint/new` path in #39. Using the `as :new_sprint` alias changes the name of `live_path` to `new_sprint_path`, which doesn't seem to serve any other purpose in the app. Removing that alias allows us to use `live_path` in our Routes helper to find the correct URL.