### PR TITLE
Two annoying bugs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,8 +43,8 @@ jobs:
           path: _build/test/lib/chippy
 
       - slack/status:
-          success_message: ":caktus: ${CIRCLE_BRANCH} tests passed. <${CIRCLE_BUILD_URL}|Build> :successful:"
-          failure_message: ":sadcactus: ${CIRCLE_BRANCH} tests failed. <${CIRCLE_BUILD_URL}|Build> :failed:"
+          success_message: ":caktus: ${CIRCLE_BRANCH} branch tests passed. <${CIRCLE_BUILD_URL}|View Build> :successful:"
+          failure_message: ":sadcactus: ${CIRCLE_BRANCH} branch tests failed. <${CIRCLE_BUILD_URL}|View Build> :failed:"
           include_project_field: false
           include_job_number_field: false
           include_visit_job_action: false

--- a/lib/chippy_web/live/sprint_live/new.ex
+++ b/lib/chippy_web/live/sprint_live/new.ex
@@ -23,7 +23,12 @@ defmodule ChippyWeb.SprintLive.New do
   end
 
   def handle_event("create", %{"name" => name}, socket) do
-    name = String.trim(name)
+    # Since we use name in our URL, don't allow '/' in them or the router gets confused.
+    # Just change them to a space for now.
+    name =
+      name
+      |> String.trim
+      |> String.replace("/", " ")
 
     new_sprint =
       case name do

--- a/lib/chippy_web/live/sprint_live/new.ex
+++ b/lib/chippy_web/live/sprint_live/new.ex
@@ -27,7 +27,7 @@ defmodule ChippyWeb.SprintLive.New do
     # Just change them to a space for now.
     name =
       name
-      |> String.trim
+      |> String.trim()
       |> String.replace("/", " ")
 
     new_sprint =

--- a/lib/chippy_web/templates/page/sprint_live.html.leex
+++ b/lib/chippy_web/templates/page/sprint_live.html.leex
@@ -49,7 +49,7 @@
     </div>
   <% end %>
 
-  <form phx-change="lookup_project" phx-submit="create_project">
+  <form id="new-project-form" phx-change="lookup_project" phx-submit="create_project">
     <div class="row">
       <div class="column column-40">
         <div class="row">


### PR DESCRIPTION
1. If you have a `/` in a sprint name, Chippy crashes and you can't add projects to that sprint. This PR changes the slash to a space so at least you can proceed
2. If a user adds a project while you are typing in an input field, your input field gets cleared when they submit. I added an HTML `id` to the form given the guidance in the [last paragraph here](https://hexdocs.pm/phoenix_live_view/form-bindings.html) and that seems to fix things (in my test with an incognito browser)