### PR TITLE
Use an Ecto changeset for project validation

### DIFF
--- a/lib/chippy/sprint.ex
+++ b/lib/chippy/sprint.ex
@@ -21,9 +21,9 @@ defmodule Chippy.Sprint do
   @doc """
   Adds a new empty project to a sprint.
 
-  Takes a project_name and an optional hour_limit which is converted to an integer.
+  Takes a project_name and an optional hour_limit which has already been converted to an integer.
 
-    iex> Sprint.new([]) |> Sprint.add_project("Foo", "22")
+    iex> Sprint.new([]) |> Sprint.add_project("Foo", 22)
     %Sprint{
       project_allocations: %{"Foo" => %{}},
       project_limits: %{"Foo" => 22}

--- a/lib/chippy/sprint.ex
+++ b/lib/chippy/sprint.ex
@@ -1,5 +1,4 @@
 defmodule Chippy.Sprint do
-  @derive Jason.Encoder
   defstruct project_allocations: %{},
             project_limits: %{}
 
@@ -31,13 +30,6 @@ defmodule Chippy.Sprint do
     }
   """
   def add_project(sprint, project_name, hour_limit) do
-    hour_limit =
-      case Integer.parse(hour_limit) do
-        # returns a 2-tuple if successful parse with value in first tuple
-        {hour_limit, _} -> hour_limit
-        :error -> 0
-      end
-
     %Sprint{
       project_allocations: Map.put(sprint.project_allocations, project_name, %{}),
       project_limits: Map.put(sprint.project_limits, project_name, hour_limit)
@@ -52,7 +44,11 @@ defmodule Chippy.Sprint do
   end
 
   def has_project?(%Sprint{project_allocations: project_allocations}, project_name) do
-    Map.has_key?(project_allocations, project_name)
+    # case insensitive search for project_name in project_allocations
+    project_allocations
+    |> Map.keys()
+    |> Enum.map(&String.downcase/1)
+    |> Enum.member?(String.downcase(project_name))
   end
 
   def sorted_allocations(sprint) do

--- a/lib/chippy/sprints/project.ex
+++ b/lib/chippy/sprints/project.ex
@@ -1,0 +1,31 @@
+defmodule Chippy.Sprints.Project do
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias Chippy.SprintServer
+
+  schema "projects" do
+    field :hour_limit, :integer
+    field :name, :string
+    field :sprint_name, :string
+  end
+
+  def validate_unique_sprint_project(changeset) do
+    sprint_name = get_field(changeset, :sprint_name)
+    project_name = get_field(changeset, :name)
+    if sprint_name && project_name && SprintServer.has_project?(sprint_name, project_name) do
+      add_error(changeset, :name, "That project exists already")
+    else
+      changeset
+    end
+  end
+
+  @doc false
+  def changeset(project, attrs) do
+    project
+    |> cast(attrs, [:name, :sprint_name, :hour_limit])
+    |> update_change(:name, &String.trim/1)
+    |> update_change(:sprint_name, &String.trim/1)
+    |> validate_required([:name, :sprint_name])
+    |> validate_unique_sprint_project()
+  end
+end

--- a/lib/chippy/sprints/project.ex
+++ b/lib/chippy/sprints/project.ex
@@ -12,6 +12,7 @@ defmodule Chippy.Sprints.Project do
   def validate_unique_sprint_project(changeset) do
     sprint_name = get_field(changeset, :sprint_name)
     project_name = get_field(changeset, :name)
+
     if sprint_name && project_name && SprintServer.has_project?(sprint_name, project_name) do
       add_error(changeset, :name, "That project exists already")
     else

--- a/lib/chippy_web/live/sprint_live/show.ex
+++ b/lib/chippy_web/live/sprint_live/show.ex
@@ -4,6 +4,7 @@ defmodule ChippyWeb.SprintLive.Show do
   alias Phoenix.PubSub
   alias Phoenix.Socket.Broadcast
   alias Chippy.SprintServer
+  alias Chippy.Sprints.Project
   alias ChippyWeb.Presence
 
   def render(assigns) do
@@ -33,6 +34,8 @@ defmodule ChippyWeb.SprintLive.Show do
   def mount(%{"sid" => sprint_id}, %{"user_id" => user_id}, socket) do
     pid_or_nil = sprint_id |> SprintServer.via_tuple() |> GenServer.whereis()
 
+    changeset = %Project{} |> Project.changeset(%{})
+
     case pid_or_nil do
       pid when is_pid(pid) ->
         PubSub.subscribe(Chippy.PubSub, "sprint:" <> sprint_id)
@@ -43,10 +46,8 @@ defmodule ChippyWeb.SprintLive.Show do
          assign(socket, %{
            sprint_id: sprint_id,
            sprint: SprintServer.display(sprint_id),
+           changeset: changeset,
            your_name: user_id,
-           name_taken: false,
-           errors: "",
-           project_name: "",
            sprint_users: sprint_users(sprint_id)
          })}
 
@@ -72,23 +73,44 @@ defmodule ChippyWeb.SprintLive.Show do
 
   def handle_event(
         "lookup_project",
-        %{"project_name" => project_name},
-        %{assigns: %{sprint_id: sprint_id}} = socket
+        %{"project" => params},
+        socket
       ) do
-    {:noreply,
-     assign(socket,
-       project_name: project_name,
-       name_taken: SprintServer.has_project?(sprint_id, project_name)
-     )}
+    changeset =
+      %Project{}
+      |> Project.changeset(params)
+      |> Map.put(:action, :insert)
+
+    socket = assign(socket, changeset: changeset)
+
+    {:noreply, socket}
   end
 
   def handle_event(
         "create_project",
-        %{"project_name" => project_name, "hour_limit" => hour_limit},
+        %{"project" => params},
         %{assigns: %{sprint_id: sprint_id}} = socket
       ) do
-    new_sprint = SprintServer.add_project(sprint_id, project_name, hour_limit)
-    update_sprint(sprint_id, new_sprint, socket)
+    changeset =
+      %Project{sprint_name: sprint_id}
+      |> Project.changeset(params)
+      |> Map.put(:action, :insert)
+
+    if changeset.valid? do
+      # apply the changeset to create a new project
+      project = Ecto.Changeset.apply_changes(changeset)
+
+      # create a new empty changeset for the form
+      changeset = %Project{} |> Project.changeset(%{})
+
+      socket = assign(socket, changeset: changeset)
+
+      new_sprint = SprintServer.add_project(sprint_id, project.name, project.hour_limit)
+      update_sprint(sprint_id, new_sprint, socket)
+    else
+      socket = assign(socket, changeset: changeset)
+      {:noreply, socket}
+    end
   end
 
   def handle_event(

--- a/lib/chippy_web/live/sprint_live/show.ex
+++ b/lib/chippy_web/live/sprint_live/show.ex
@@ -74,10 +74,10 @@ defmodule ChippyWeb.SprintLive.Show do
   def handle_event(
         "lookup_project",
         %{"project" => params},
-        socket
+        %{assigns: %{sprint_id: sprint_id}} = socket
       ) do
     changeset =
-      %Project{}
+      %Project{sprint_name: sprint_id}
       |> Project.changeset(params)
       |> Map.put(:action, :insert)
 

--- a/lib/chippy_web/templates/page/sprint_live.html.leex
+++ b/lib/chippy_web/templates/page/sprint_live.html.leex
@@ -49,42 +49,38 @@
     </div>
   <% end %>
 
-  <form id="new-project-form" phx-change="lookup_project" phx-submit="create_project">
+  <%= f = form_for @changeset, "#",
+      phx_submit: "create_project",
+      phx_change: "lookup_project" %>
     <div class="row">
-      <div class="column column-40">
+      <div class="column column-20">
         <div class="row">
-          <input
-            type="text"
-            name="project_name"
-            placeholder="Project name"
-            pattern="\S+.*"
-            required
-            autofocus
-          />
-          <input
-            type="number"
-            name="hour_limit"
-            placeholder="PM Allocation"
-          />
+          <%= text_input f, :name,
+              placeholder: "Name",
+              autofocus: "on",
+              autocomplete: "off" %>
+        </div>
+        <div class="row">
+          <%= error_tag f, :name %>
+        </div>
+      </div>
+      <div class="column column-20">
+        <div class="row">
+          <%= number_input f, :hour_limit,
+              placeholder: "PM Allocation" %>
+        </div>
+        <div class="row">
+          <%= error_tag f, :hour_limit %>
         </div>
       </div>
       <div class="column column-40">
         <div class="row">
-          <button
-            <%= if String.trim(@project_name) == "" || @name_taken, do: "disabled", else: "" %>
-          >
+          <button>
             Add project
           </button>
         </div>
       </div>
     </div>
-    <%= if @name_taken do %>
-      <div class="row">
-        <div class="error">
-          That project name is taken.
-        </div>
-      </div>
-    <% end %>
   </form>
 </section>
 

--- a/lib/chippy_web/templates/page/sprint_live.html.leex
+++ b/lib/chippy_web/templates/page/sprint_live.html.leex
@@ -58,7 +58,8 @@
           <%= text_input f, :name,
               placeholder: "Name",
               autofocus: "on",
-              autocomplete: "off" %>
+              autocomplete: "off",
+              phx_debounce: "500" %>
         </div>
         <div class="row">
           <%= error_tag f, :name %>

--- a/lib/chippy_web/views/page_view.ex
+++ b/lib/chippy_web/views/page_view.ex
@@ -4,7 +4,7 @@ defmodule ChippyWeb.PageView do
   @doc """
   Returns the hour_limit for a particular project.
 
-    iex> Sprint.new([]) |> Sprint.add_project("Foo", "22") |> PageView.hour_limit("Foo")
+    iex> Sprint.new([]) |> Sprint.add_project("Foo", 22) |> PageView.hour_limit("Foo")
     22
   """
   def hour_limit(sprint, project_name) do

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 awscli<1.19
 boto<2.50
 boto3<1.15
-git+https://github.com/caktus/invoke-kubesae@0.0.5#egg=invoke-kubesae
+git+https://github.com/caktus/invoke-kubesae@0.0.9#egg=invoke-kubesae
 kubernetes-validate<1.19
 openshift<0.12


### PR DESCRIPTION
Using Ecto changesets is the only way to make it so that changes on one client don't clobber the input fields on a separate client. You can use Ecto without storing things in the DB, so I thought I'd try that first. You can think of a changeset as a similar concept to Django forms. You create empty changesets for new forms, and then validate submitted data using a changeset, which then provides errors that you can transmit back to the form.

I also added case-insensitive uniqueness checks for project names.